### PR TITLE
add comments in tasks activiy log 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ yarn-error.log
 /.idea
 /.vscode
 *.sqlite.*
+*.sqlite
+

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ yarn-error.log
 /.fleet
 /.idea
 /.vscode
+*.sqlite.*

--- a/app/Filament/App/Resources/TaskResource.php
+++ b/app/Filament/App/Resources/TaskResource.php
@@ -473,7 +473,8 @@ class TaskResource extends Resource
                                                     ->dateTime()
                                                     ->timezone(PejotaHelper::getUserTimeZone()),
                                                 TextEntry::make('description')
-                                                    ->label(''),
+                                                    ->label('Comment')
+                                                    ->getStateUsing(fn(Model $record): array => key_exists('comment', $record->properties->get('attributes')) ? [$record->properties->get('attributes')['comment']] : ["--"]),
                                                 TextEntry::make('causer.name')
                                                     ->label(''),
                                                 TextEntry::make('properties.attributes')

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -10,10 +10,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use NunoMazer\Samehouse\BelongsToTenants;
+use Parallax\FilamentComments\Models\FilamentComment;
 use Parallax\FilamentComments\Models\Traits\HasFilamentComments;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Tags\HasTags;
+
+use function Laravel\Prompts\error;
 
 class Task extends Model
 {
@@ -108,6 +111,11 @@ class Task extends Model
             ->useLogName(self::LOG_NAME)
             ->dontSubmitEmptyLogs()
             ->logOnlyDirty();
+    }
+
+    public function filamentComments(): HasMany
+    {
+        return $this->hasMany(FilamentComment::class, 'subject_id');
     }
 
     public function scopeOpened(Builder $query)

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Task;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Parallax\FilamentComments\Models\FilamentComment;
+
+class EventServiceProvider extends ServiceProvider
+{
+
+    public function boot()
+    {
+        parent::boot();
+
+        Event::listen(
+            FilamentComment::creating(function ($comment) {
+                if ($comment->subject_type == "App\\Models\\Task") {
+                    $task = Task::where('id', $comment->subject_id)->first();
+                    
+                    $properties = [
+                        'comment' => 'New comment: '. strip_tags($comment->comment),
+                        'status.name'=> $task->status->name, // Supondo que Task tenha uma relação com Status
+                    ];
+        
+                    $dirtyAttributes = $task->getDirty();
+                    $dirtyProperties = [];
+
+                    foreach ($dirtyAttributes as $key => $value) {
+                        $dirtyProperties[$key] = [
+                            'old' => $task->getOriginal($key),
+                            'new' => $value,
+                        ];
+                    }
+
+                    activity('task')
+                        ->performedOn($task)
+                        ->withProperties(['attributes' => $properties])
+                        ->log('update');
+                }
+            })
+        );
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -4,4 +4,5 @@ return [
     App\Providers\AppServiceProvider::class,
     App\Providers\Filament\AdminPanelProvider::class,
     App\Providers\Filament\AppPanelProvider::class,
+    App\Providers\EventServiceProvider::class
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -122,5 +122,4 @@ return [
         'driver' => env('APP_MAINTENANCE_DRIVER', 'file'),
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
-
 ];


### PR DESCRIPTION
Hey @nunomazer,

I was trying to address partial issue #18 , but i not pretty sure if i had use best approach, i had a problem trying to create an activity log to FilamentComment, because the FilamentComment model came from filament package, and iam not be able to add a task relation to it. like i said probably there is a better approach, so if it really exists pls let me know, i would really appreciate it..

-> Create an Event service provider who listens to FilamentComment model creating action and add a log to a linked task searching by subject foreign key id.