### PR TITLE
Harden attachment downloads

### DIFF
--- a/app/Http/Controllers/AttachmentsController.php
+++ b/app/Http/Controllers/AttachmentsController.php
@@ -7,16 +7,39 @@ use Illuminate\Support\Facades\Storage;
 
 class AttachmentsController extends Controller
 {
+    private const SERVABLE_DISKS = [
+        'tasks',
+        'projects',
+        'work_sessions',
+        'companies',
+        'companies-logo',
+    ];
+
     public function getAttachment(string $module, int $companyId, string $fileName)
     {
-        if ($module == 'companies-logo') {
-            return Storage::disk($module)->response($companyId.'/'.$fileName);
+        if (! in_array($module, self::SERVABLE_DISKS, true)) {
+            abort(404);
         }
 
-        if (Company::whereKey($companyId)->first()?->hasMember(auth()->user())) {
-            return Storage::disk($module)->response($companyId.'/'.$fileName);
+        if ($this->containsPathSeparator($fileName)) {
+            abort(404);
         }
 
-        abort(404);
+        $path = $companyId.'/'.$fileName;
+
+        abort_unless(
+            Company::whereKey($companyId)->first()?->hasMember(auth()->user())
+                && Storage::disk($module)->exists($path),
+            404
+        );
+
+        return Storage::disk($module)->response($path);
+    }
+
+    private function containsPathSeparator(string $fileName): bool
+    {
+        return str_contains($fileName, '/')
+            || str_contains($fileName, '\\')
+            || in_array($fileName, ['.', '..'], true);
     }
 }

--- a/tests/Feature/Tenancy/AttachmentsAuthorizationTest.php
+++ b/tests/Feature/Tenancy/AttachmentsAuthorizationTest.php
@@ -51,4 +51,77 @@ class AttachmentsAuthorizationTest extends TestCase
 
         $response->assertNotFound();
     }
+
+    public function test_member_can_download_their_company_logo(): void
+    {
+        Storage::fake('companies-logo');
+
+        $user = User::factory()->create();
+        $company = $user->companies()->firstOrFail();
+
+        Storage::disk('companies-logo')->put($company->id.'/logo.png', 'image');
+
+        $response = $this->actingAs($user)->get(
+            route('attachments.get', [
+                'module' => 'companies-logo',
+                'companyId' => $company->id,
+                'fileName' => 'logo.png',
+            ])
+        );
+
+        $response->assertOk();
+    }
+
+    public function test_non_member_cannot_download_another_companys_logo(): void
+    {
+        Storage::fake('companies-logo');
+
+        $user = User::factory()->create();
+        $owner = User::factory()->create();
+        $foreignCompany = $owner->companies()->firstOrFail();
+
+        Storage::disk('companies-logo')->put($foreignCompany->id.'/logo.png', 'image');
+
+        $response = $this->actingAs($user)->get(
+            route('attachments.get', [
+                'module' => 'companies-logo',
+                'companyId' => $foreignCompany->id,
+                'fileName' => 'logo.png',
+            ])
+        );
+
+        $response->assertNotFound();
+    }
+
+    public function test_unconfigured_disk_names_are_rejected(): void
+    {
+        $user = User::factory()->create();
+        $company = $user->companies()->firstOrFail();
+
+        $response = $this->actingAs($user)->get(
+            route('attachments.get', [
+                'module' => 'local',
+                'companyId' => $company->id,
+                'fileName' => 'report.pdf',
+            ])
+        );
+
+        $response->assertNotFound();
+    }
+
+    public function test_attachment_names_containing_path_separators_are_rejected(): void
+    {
+        Storage::fake('tasks');
+
+        $user = User::factory()->create();
+        $company = $user->companies()->firstOrFail();
+
+        Storage::disk('tasks')->put($company->id.'/nested/report.pdf', 'contents');
+
+        $response = $this->actingAs($user)->get(
+            "/attachments/tasks/{$company->id}/nested%5Creport.pdf"
+        );
+
+        $response->assertNotFound();
+    }
 }


### PR DESCRIPTION
## Summary

- restrict attachment downloads to the configured attachment disks
- require company membership before serving company logos
- reject attachment names that contain path separators
- return 404 for missing or unauthorized attachment requests

## Tests

- `php -l app/Http/Controllers/AttachmentsController.php`
- `php -l tests/Feature/Tenancy/AttachmentsAuthorizationTest.php`

The full Laravel test suite was not run locally because Composer dependencies are not installed in this checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correções**
  * Reforçada a autorização para download de anexos: somente membros da empresa podem acessar os arquivos, incluindo logos.
  * Discos não permitidos agora retornam erro 404.
  * Nomes de arquivos com separadores de caminho são rejeitados com erro 404.
  * Adicionadas validações para confirmar a existência do arquivo antes do download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->